### PR TITLE
ZEPPELIN-319 optionally wait an additional .5 seconds, if assertion c…

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -117,6 +117,14 @@ public class RemoteSchedulerTest {
     assertEquals(1, scheduler.getJobsRunning().size());
 
     Thread.sleep(500);
+    
+    /* Test if our assertion will fail, if so,
+     * maybe the thread is just slow, give it some more time.
+     */
+    if (scheduler.getJobsRunning().size() == 1 
+     || scheduler.getJobsWaiting().size() == 1) {
+      Thread.sleep(500);
+    }
 
     assertEquals(0, scheduler.getJobsWaiting().size());
     assertEquals(0, scheduler.getJobsRunning().size());


### PR DESCRIPTION
…an be expected to fail

This test failed randomly during a build. To make sure this is not due to timing issues, we can optionally wait an additional .5 seconds.
This is a band-aid around bad design, but I'm pragmatically trying to get the build to be more stable.

Please review, and if you can come up with a better designed test we should discuss it here or in the issue.